### PR TITLE
fix: pagination, slash-filename crash, 5xx retry, and partial-failure threshold

### DIFF
--- a/repo-template/.github/workflows/pull-from-sigma.yml
+++ b/repo-template/.github/workflows/pull-from-sigma.yml
@@ -36,6 +36,9 @@ jobs:
         env:
           SIGMA_CLIENT_ID: ${{ secrets.SIGMA_CLIENT_ID }}
           SIGMA_SECRET: ${{ secrets.SIGMA_SECRET }}
+          # Set SIGMA_PULL_MAX_FAILURES in repo secrets/vars to tolerate N
+          # persistently-broken models without blocking the PR for healthy ones.
+          SIGMA_PULL_MAX_FAILURES: ${{ vars.SIGMA_PULL_MAX_FAILURES || '0' }}
         run: python scripts/pull_from_sigma.py
 
       - name: Check for changes

--- a/repo-template/scripts/pull_from_sigma.py
+++ b/repo-template/scripts/pull_from_sigma.py
@@ -17,6 +17,7 @@ Environment variables:
 import os
 import sys
 import json
+import time
 import yaml
 import argparse
 import requests
@@ -113,31 +114,52 @@ class SigmaClient:
         }
     
     def list_data_models(self):
-        response = requests.get(
-            f"{self.base_url}/v2/datamodels",
-            headers=self._headers()
-        )
-        
-        if response.status_code != 200:
-            raise Exception(f"Failed to list data models: {response.text}")
-        
-        return response.json().get('entries', [])
+        entries = []
+        params = {'limit': 1000}
+        while True:
+            response = requests.get(
+                f"{self.base_url}/v2/datamodels",
+                headers=self._headers(),
+                params=params,
+            )
+            if response.status_code != 200:
+                raise Exception(f"Failed to list data models: {response.text}")
+            body = response.json()
+            entries.extend(body.get('entries', []))
+            next_page = body.get('nextPage')
+            if not next_page:
+                break
+            params['page'] = next_page
+        return entries
     
     def get_data_model_spec(self, data_model_id):
-        response = requests.get(
-            f"{self.base_url}/v3alpha/datamodels/{data_model_id}/spec",
-            headers=self._headers()
-        )
-        
-        if response.status_code != 200:
-            raise Exception(f"Failed to get data model spec: {response.text}")
-        
-        return response.json()
+        last_error = None
+        for attempt in range(4):
+            try:
+                response = requests.get(
+                    f"{self.base_url}/v3alpha/datamodels/{data_model_id}/spec",
+                    headers=self._headers(),
+                    timeout=30,
+                )
+            except requests.RequestException as e:
+                last_error = f"Network error: {e}"
+            else:
+                if response.status_code == 200:
+                    return response.json()
+                if response.status_code < 500:
+                    raise Exception(f"Failed to get data model spec: {response.text}")
+                last_error = f"HTTP {response.status_code}: {response.text}"
+
+            if attempt < 3:
+                time.sleep(2 ** attempt)
+
+        raise Exception(f"Failed to get data model spec after retries: {last_error}")
 
 
 def sanitize_filename(name):
     """Convert name to a safe filename."""
-    return name.lower().replace(' ', '-').replace('_', '-').\
+    return name.replace('/', '-').replace('\\', '-').\
+        lower().replace(' ', '-').replace('_', '-').\
         encode('ascii', 'ignore').decode().\
         replace('--', '-').strip('-')[:50] or 'unnamed'
 
@@ -239,7 +261,8 @@ def main():
     print(f"📂 Output: {output_dir}/")
     print("=" * 60)
     
-    if failed > 0:
+    max_failures = int(os.environ.get('SIGMA_PULL_MAX_FAILURES', '0'))
+    if failed > max_failures:
         sys.exit(1)
 
 

--- a/repo-template/scripts/sync_to_sigma.py
+++ b/repo-template/scripts/sync_to_sigma.py
@@ -16,6 +16,7 @@ Environment variables:
 import os
 import sys
 import json
+import time
 import yaml
 import requests
 from pathlib import Path
@@ -115,27 +116,47 @@ class SigmaClient:
     
     def list_data_models(self):
         """Get all data models from Sigma."""
-        response = requests.get(
-            f"{self.base_url}/v2/datamodels",
-            headers=self._headers()
-        )
-        
-        if response.status_code != 200:
-            raise Exception(f"Failed to list data models: {response.text}")
-        
-        return response.json().get('entries', [])
+        entries = []
+        params = {'limit': 1000}
+        while True:
+            response = requests.get(
+                f"{self.base_url}/v2/datamodels",
+                headers=self._headers(),
+                params=params,
+            )
+            if response.status_code != 200:
+                raise Exception(f"Failed to list data models: {response.text}")
+            body = response.json()
+            entries.extend(body.get('entries', []))
+            next_page = body.get('nextPage')
+            if not next_page:
+                break
+            params['page'] = next_page
+        return entries
     
     def get_data_model_spec(self, data_model_id):
         """Get the JSON representation of a data model."""
-        response = requests.get(
-            f"{self.base_url}/v3alpha/datamodels/{data_model_id}/spec",
-            headers=self._headers()
-        )
-        
-        if response.status_code != 200:
-            raise Exception(f"Failed to get data model spec: {response.text}")
-        
-        return response.json()
+        last_error = None
+        for attempt in range(4):
+            try:
+                response = requests.get(
+                    f"{self.base_url}/v3alpha/datamodels/{data_model_id}/spec",
+                    headers=self._headers(),
+                    timeout=30,
+                )
+            except requests.RequestException as e:
+                last_error = f"Network error: {e}"
+            else:
+                if response.status_code == 200:
+                    return response.json()
+                if response.status_code < 500:
+                    raise Exception(f"Failed to get data model spec: {response.text}")
+                last_error = f"HTTP {response.status_code}: {response.text}"
+
+            if attempt < 3:
+                time.sleep(2 ** attempt)
+
+        raise Exception(f"Failed to get data model spec after retries: {last_error}")
     
     def create_data_model(self, spec):
         """Create a new data model from a JSON spec."""
@@ -330,7 +351,8 @@ def main():
     print(f"✅ Synced: {success}  ❌ Failed: {failed}")
     print("=" * 60)
     
-    if failed > 0:
+    max_failures = int(os.environ.get('SIGMA_SYNC_MAX_FAILURES', '0'))
+    if failed > max_failures:
         sys.exit(1)
 
 


### PR DESCRIPTION
Fixes all four open issues in one pass — each change is independent but they compound (e.g. retry makes issue #4 less common, but #4 is still needed for persistent server-side failures).

## Changes

### #1 — `list_data_models()` doesn't paginate (`pull` + `sync`)
Replaced the single-shot `GET /v2/datamodels` with a `nextPage` cursor loop using `limit=1000`. Both scripts were affected; both fixed identically.

### #2 — `sanitize_filename()` crashes on model names with `/` or `\` (`pull` only)
Path separators are now replaced with `-` as the first step in the pipeline, before lowercasing and ASCII encoding. A name like `CA Case/Queue Mgmt` now becomes `ca-case-queue-mgmt.json` instead of trying to open a nonexistent subdirectory.

### #3 — `get_data_model_spec()` has no retry on 5xx (`pull` + `sync`)
Wrapped the spec fetch in a 4-attempt exponential-backoff loop (waits: 1s, 2s, 4s). 4xx responses are not retried (permanent errors). Network exceptions are retried. Both scripts fixed identically.

### #4 — `sys.exit(1)` on any failure blocks PR creation for persistently-broken models (`pull`)
`pull_from_sigma.py` now reads `SIGMA_PULL_MAX_FAILURES` (integer, default `0`) and only exits non-zero when `failed > max_failures`. Default of `0` preserves current strict behavior — no behavior change unless the env var is set. The workflow now passes `vars.SIGMA_PULL_MAX_FAILURES` through so repo admins can configure it without touching the script. Applied the same pattern to `sync_to_sigma.py` via `SIGMA_SYNC_MAX_FAILURES`.

## Test plan
- [ ] Tenant with >50 models: confirm all models are pulled (not just first ~50)
- [ ] Create a Sigma model named `Foo/Bar`, run pull, confirm file is `foo-bar.json` not a crash
- [ ] Mock a single 500 on `get_data_model_spec`: confirm the run retries and succeeds on the second attempt
- [ ] With two persistently-500 models, set `SIGMA_PULL_MAX_FAILURES=2` in repo vars and confirm the workflow still opens a PR for the healthy models

🤖 Generated with [Claude Code](https://claude.com/claude-code)